### PR TITLE
Add competitor store seeder and map interface

### DIFF
--- a/app/Http/Controllers/CompetitorStoreController.php
+++ b/app/Http/Controllers/CompetitorStoreController.php
@@ -32,6 +32,9 @@ class CompetitorStoreController extends Controller
     {
         $model = new CompetitorStore;
         $model->name = $request->name;
+        $model->address = $request->address;
+        $model->latitude = $request->latitude;
+        $model->longitude = $request->longitude;
         $model->franchise_id = $request->franchise_id;
         $model->opened_year = $request->opened_year;
         $model->save();
@@ -49,6 +52,9 @@ class CompetitorStoreController extends Controller
     {
         $model = CompetitorStore::find($id);
         $model->name = $request->name;
+        $model->address = $request->address;
+        $model->latitude = $request->latitude;
+        $model->longitude = $request->longitude;
         $model->franchise_id = $request->franchise_id;
         $model->opened_year = $request->opened_year;
         $model->save();

--- a/app/Models/CompetitorStore.php
+++ b/app/Models/CompetitorStore.php
@@ -6,7 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class CompetitorStore extends Model
 {
-    protected $fillable = ['name', 'franchise_id', 'opened_year'];
+    protected $fillable = [
+        'name',
+        'franchise_id',
+        'opened_year',
+        'address',
+        'latitude',
+        'longitude',
+    ];
 
     public function franchise()
     {

--- a/database/data/competitor_stores.json
+++ b/database/data/competitor_stores.json
@@ -1,0 +1,200 @@
+[
+  {
+    "Tienda": "Falabella",
+    "Dirección": "Cra. 14 #56d-1",
+    "Latitud": 4.9654,
+    "Longitud": -75.5097
+  },
+  {
+    "Tienda": "Farmatodo",
+    "Dirección": "Av. Santander #62-96",
+    "Latitud": 5.0673,
+    "Longitud": -75.4839
+  },
+  {
+    "Tienda": "Farmatodo La Florida",
+    "Dirección": "Av. Santander #62-96",
+    "Latitud": 5.0673,
+    "Longitud": -75.4839
+  },
+  {
+    "Tienda": "Kumalinda Piel - Cableplaza",
+    "Dirección": "Carrera 23 # 65-11 CC Cable Plaza Loc 122B",
+    "Latitud": 5.0679,
+    "Longitud": -75.4837
+  },
+  {
+    "Tienda": "Linda Piel - Milan",
+    "Dirección": "Cr 23 No: 71-117",
+    "Latitud": 5.0694,
+    "Longitud": -75.4862
+  },
+  {
+    "Tienda": "Linea Estetica Fundadores",
+    "Dirección": "Calle 33 B.º 20 03",
+    "Latitud": 5.064,
+    "Longitud": -75.4975
+  },
+  {
+    "Tienda": "Linea Estetica Mall Plaza",
+    "Dirección": "Carrera 14, C.C. Mallplaza Manizales, Av. Kevin Ángel #55D – 251 Local 2145",
+    "Latitud": 5.0592,
+    "Longitud": -75.4879
+  },
+  {
+    "Tienda": "Medipiel - Fundadores",
+    "Dirección": "Cl. 33b #20 -03 Local 262",
+    "Latitud": 5.0617,
+    "Longitud": -75.4984
+  },
+  {
+    "Tienda": "Medipiel - Mall Plaza",
+    "Dirección": "Av. Kevin Ángel #55D – 251 Local 1072A",
+    "Latitud": 5.0592,
+    "Longitud": -75.4879
+  },
+  {
+    "Tienda": "Naturell Misukone Center - Las Palmas",
+    "Dirección": "Edificio Los Rosales, Av. Santander #57 - 03 local 201",
+    "Latitud": 5.0638,
+    "Longitud": -75.4809
+  },
+  {
+    "Tienda": "Para tu piel - Estrella",
+    "Dirección": "Parque Estrella, Cl. 61a #24B-21",
+    "Latitud": 5.0655,
+    "Longitud": -75.4965
+  },
+  {
+    "Tienda": "Profamiliar",
+    "Dirección": "Carrera 22, Av. Del Centro #25-03",
+    "Latitud": 5.066,
+    "Longitud": -75.5005
+  },
+  {
+    "Tienda": "Skin Life Centro Comercial Sancancio",
+    "Dirección": "C.C Sancancio, Carrera 27 A 66-30, Local 850",
+    "Latitud": 5.0622,
+    "Longitud": -75.4922
+  },
+  {
+    "Tienda": "Skin Life Palermo",
+    "Dirección": "Cl. 66 #No 27 A 08",
+    "Latitud": 5.0624,
+    "Longitud": -75.4912
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Santander #60-2",
+    "Latitud": 5.0673,
+    "Longitud": -75.4831
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Santander #49 -83 Plaza 51 Local 16",
+    "Latitud": 5.0637,
+    "Longitud": -75.4996
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cl. 66 #27-15",
+    "Latitud": 5.0624,
+    "Longitud": -75.4917
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Barrio san José, Coldeportes, Av. Santander #47-117",
+    "Latitud": 5.0632,
+    "Longitud": -75.498
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Santander #65 A - 41 Local P-201",
+    "Latitud": 5.0683,
+    "Longitud": -75.4842
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Centro, Av. Santander #62 -16 Local 112",
+    "Latitud": 5.0678,
+    "Longitud": -75.4837
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Av. Santander #65-11 Local 102",
+    "Latitud": 5.0682,
+    "Longitud": -75.4842
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Santander #60 - 74",
+    "Latitud": 5.0673,
+    "Longitud": -75.4831
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Centro Comercial Multicentro Estrella, Av. Santander #59 - 70 Local 8",
+    "Latitud": 5.0673,
+    "Longitud": -75.4831
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde la 48 Av. Santander #47-109",
+    "Latitud": 5.0632,
+    "Longitud": -75.498
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Edificio Cervantes El Cable - El Cable, Av. Santander #64 - 17 Local 10",
+    "Latitud": 5.0679,
+    "Longitud": -75.4837
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde Cl. 67 #26 -28",
+    "Latitud": 5.0624,
+    "Longitud": -75.4917
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Kevin Ángel #65-180 Local 5",
+    "Latitud": 5.0683,
+    "Longitud": -75.4842
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Centro Comercial Fundadores, Cl. 33b #20 - 03 L-102 Nivel 1",
+    "Latitud": "No encontrado",
+    "Longitud": "No encontrado"
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Palogrande Edificio Secuoya, Calle 66 # 27 - 23",
+    "Latitud": 5.0624,
+    "Longitud": -75.4917
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Barrio Alta Suiza, Tv. 72 #20 - 29",
+    "Latitud": 5.0691,
+    "Longitud": -75.486
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cra. 23 #26-31 · Multicentro Estrella Centro Comercial Cra. 23a #59-70",
+    "Latitud": 5.0657,
+    "Longitud": -75.4991
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Cruz Verde San Marcel Vía Panamericana #30",
+    "Latitud": 5.0305,
+    "Longitud": -75.4975
+  },
+  {
+    "Tienda": "Cruz Verde",
+    "Dirección": "Av. Santander #74 - 02",
+    "Latitud": 5.0695,
+    "Longitud": -75.4863
+  }
+]

--- a/database/migrations/2025_02_01_000002_add_location_fields_to_competitor_stores_table.php
+++ b/database/migrations/2025_02_01_000002_add_location_fields_to_competitor_stores_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('competitor_stores', function (Blueprint $table) {
+            $table->string('address')->nullable();
+            $table->decimal('latitude', 10, 6)->nullable();
+            $table->decimal('longitude', 10, 6)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('competitor_stores', function (Blueprint $table) {
+            $table->dropColumn(['address', 'latitude', 'longitude']);
+        });
+    }
+};

--- a/database/seeders/CompetitorStoreSeeder.php
+++ b/database/seeders/CompetitorStoreSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\CompetitorStore;
+
+class CompetitorStoreSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = base_path('database/data/competitor_stores.json');
+        $data = json_decode(file_get_contents($path), true);
+        foreach ($data as $item) {
+            if (is_numeric($item['Latitud']) && is_numeric($item['Longitud'])) {
+                CompetitorStore::create([
+                    'name' => $item['Tienda'],
+                    'address' => $item['Dirección'],
+                    'latitude' => $item['Latitud'],
+                    'longitude' => $item['Longitud'],
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -89,13 +89,15 @@ class DatabaseSeeder extends Seeder
                 'settings' => json_encode([
                     'webhook_url' => 'https://api.watoolbox.com/webhooks/YCSKQA0CJ',
                     'phone_number' => '573148358924',
-                    
+
                 ]),
                 'APIKEY' => 'fL2@£H@knd13b9JSBN;H\b;#bBz_67FQX*f^0bEKAF.n7-QfPp%',
-                
-                
+
+
             ]
         ]);
+
+        $this->call(CompetitorStoreSeeder::class);
     }
 
 }

--- a/resources/views/competitor_stores/create.blade.php
+++ b/resources/views/competitor_stores/create.blade.php
@@ -9,6 +9,18 @@
         <input type="text" name="name" class="form-control" required>
     </div>
     <div class="form-group">
+        <label>Dirección:</label>
+        <input type="text" name="address" class="form-control">
+    </div>
+    <div class="form-group">
+        <label>Latitud:</label>
+        <input type="text" name="latitude" class="form-control">
+    </div>
+    <div class="form-group">
+        <label>Longitud:</label>
+        <input type="text" name="longitude" class="form-control">
+    </div>
+    <div class="form-group">
         <label>Franquicia:</label>
         <select name="franchise_id" class="form-control">
             <option value="">-- Ninguna --</option>

--- a/resources/views/competitor_stores/edit.blade.php
+++ b/resources/views/competitor_stores/edit.blade.php
@@ -9,6 +9,18 @@
         <input type="text" name="name" class="form-control" value="{{$model->name}}" required>
     </div>
     <div class="form-group">
+        <label>Dirección:</label>
+        <input type="text" name="address" class="form-control" value="{{$model->address}}">
+    </div>
+    <div class="form-group">
+        <label>Latitud:</label>
+        <input type="text" name="latitude" class="form-control" value="{{$model->latitude}}">
+    </div>
+    <div class="form-group">
+        <label>Longitud:</label>
+        <input type="text" name="longitude" class="form-control" value="{{$model->longitude}}">
+    </div>
+    <div class="form-group">
         <label>Franquicia:</label>
         <select name="franchise_id" class="form-control">
             <option value="">-- Ninguna --</option>

--- a/resources/views/competitor_stores/index.blade.php
+++ b/resources/views/competitor_stores/index.blade.php
@@ -19,6 +19,9 @@
     <thead>
         <tr>
             <th>Nombre</th>
+            <th>Dirección</th>
+            <th>Latitud</th>
+            <th>Longitud</th>
             <th>Franquicia</th>
             <th>Año de apertura</th>
             <th>Acciones</th>
@@ -28,6 +31,9 @@
         @foreach($model as $item)
         <tr>
             <td>{{$item->name}}</td>
+            <td>{{$item->address}}</td>
+            <td>{{$item->latitude}}</td>
+            <td>{{$item->longitude}}</td>
             <td>@if(isset($item->franchise)){{$item->franchise->name}}@endif</td>
             <td>{{$item->opened_year}}</td>
             <td>
@@ -38,4 +44,22 @@
         @endforeach
     </tbody>
 </table>
+
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<div id="map" style="width: 100%; height: 400px;"></div>
+<script>
+    var map = L.map('map').setView([5.0673, -75.4839], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+    var stores = @json($model);
+    stores.forEach(function(store){
+        if(store.latitude && store.longitude){
+            L.marker([store.latitude, store.longitude]).addTo(map)
+                .bindPopup('<b>'+store.name+'</b><br>'+ (store.address || ''));
+        }
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- add migration for competitor store locations
- create seed data JSON and seeder
- register seeder in DatabaseSeeder
- allow CompetitorStore to store address and coordinates
- update competitor store CRUD views and controller
- show stores on map with Leaflet

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685086a7dbc883318ed4dd33f0497edd