### PR TITLE
Add map to competitor edit view

### DIFF
--- a/app/Http/Controllers/CompetitorStoreController.php
+++ b/app/Http/Controllers/CompetitorStoreController.php
@@ -15,9 +15,14 @@ class CompetitorStoreController extends Controller
             ->orderBy('opened_year', 'desc')
             ->pluck('opened_year');
 
+        $franchises = Franchise::all();
+
         $model = CompetitorStore::with('franchise')
             ->when($request->input('years'), function ($q) use ($request) {
                 $q->whereIn('opened_year', (array) $request->input('years'));
+            })
+            ->when($request->input('franchises'), function ($q) use ($request) {
+                $q->whereIn('franchise_id', (array) $request->input('franchises'));
             })
             ->orderBy('opened_year', 'desc')
             ->get();
@@ -25,6 +30,7 @@ class CompetitorStoreController extends Controller
         return view('competitor_stores.index', [
             'model' => $model,
             'years' => $years,
+            'franchises' => $franchises,
             'request' => $request,
         ]);
     }

--- a/resources/views/competitor_stores/edit.blade.php
+++ b/resources/views/competitor_stores/edit.blade.php
@@ -14,12 +14,17 @@
     </div>
     <div class="form-group">
         <label>Latitud:</label>
-        <input type="text" name="latitude" class="form-control" value="{{$model->latitude}}">
+        <input id="latitude" type="text" name="latitude" class="form-control" value="{{$model->latitude}}">
     </div>
     <div class="form-group">
         <label>Longitud:</label>
-        <input type="text" name="longitude" class="form-control" value="{{$model->longitude}}">
+        <input id="longitude" type="text" name="longitude" class="form-control" value="{{$model->longitude}}">
     </div>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+    <style>
+        #map { width: 100%; height: 300px; }
+    </style>
+    <div id="map" class="mb-3"></div>
     <div class="form-group">
         <label>Franquicia:</label>
         <select name="franchise_id" class="form-control">
@@ -35,4 +40,32 @@
     </div>
     <button type="submit" class="btn btn-primary">Actualizar</button>
 </form>
+
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<script>
+    var latInput = document.getElementById('latitude');
+    var lngInput = document.getElementById('longitude');
+    var lat = parseFloat(latInput.value) || 5.0673;
+    var lng = parseFloat(lngInput.value) || -75.4839;
+
+    var map = L.map('map').setView([lat, lng], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    var marker = L.marker([lat, lng]).addTo(map);
+
+    function updateMarker() {
+        var lat = parseFloat(latInput.value);
+        var lng = parseFloat(lngInput.value);
+        if (!isNaN(lat) && !isNaN(lng)) {
+            marker.setLatLng([lat, lng]);
+            map.panTo([lat, lng]);
+        }
+    }
+
+    latInput.addEventListener('input', updateMarker);
+    lngInput.addEventListener('input', updateMarker);
+</script>
 @endsection

--- a/resources/views/competitor_stores/index.blade.php
+++ b/resources/views/competitor_stores/index.blade.php
@@ -22,12 +22,23 @@
 <div id="map" style="width: 100%; height: 500px;" class="mb-4"></div>
 
 <div class="mb-3">
-    <form method="GET" action="/competitor-stores" class="form-inline">
+    <form id="filter-form" method="GET" action="/competitor-stores" class="form-inline">
         <label class="mr-2">Años:</label>
         <div class="form-group mr-3">
             @foreach($years as $y)
                 <label class="mr-2">
                     <input type="checkbox" name="years[]" value="{{$y}}" @if(is_array(request('years')) && in_array($y, request('years'))) checked @endif> {{$y}}
+                </label>
+            @endforeach
+        </div>
+        <div class="form-group mr-3">
+            <label class="mr-2">Franquicias:</label>
+            @foreach($franchises as $f)
+                @php
+                    $checked = !request('franchises') || in_array($f->id, (array) request('franchises'));
+                @endphp
+                <label class="mr-2">
+                    <input type="checkbox" name="franchises[]" value="{{$f->id}}" @if($checked) checked @endif> {{$f->name}}
                 </label>
             @endforeach
         </div>
@@ -121,6 +132,12 @@
             link.href = canvas.toDataURL('image/png');
             link.download = 'mapa.png';
             link.click();
+        });
+    });
+
+    document.querySelectorAll('input[name="franchises[]"]').forEach(function(cb){
+        cb.addEventListener('change', function(){
+            document.getElementById('filter-form').submit();
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- add Leaflet map preview to edit competitor store page so you can verify coordinates
- add franchise filter checkboxes to competitor map that auto-submit on change

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588956454c8331af862f4fd141ca25